### PR TITLE
fix: Add WeatherForecast model

### DIFF
--- a/BcodeSeed.Api/WeatherForecast.cs
+++ b/BcodeSeed.Api/WeatherForecast.cs
@@ -1,0 +1,8 @@
+namespace BcodeSeed.Api;
+
+public record WeatherForecast
+{
+    public DateOnly Date { get; init; }
+    public int TemperatureC { get; init; }
+    public string? Summary { get; init; }
+}


### PR DESCRIPTION
## Summary
- add a WeatherForecast record matching the fields used by the controller

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*
