### PR TITLE
Add development config and doc

### DIFF
--- a/BcodeSeed.Api/appsettings.Development.json
+++ b/BcodeSeed.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Debug"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ dotnet run --project BcodeSeed.Api
 
 By default the API listens on `https://localhost:5001` (and `http://localhost:5000`). Swagger UI will be available at `https://localhost:5001/swagger`.
 
+ASP.NET Core automatically loads configuration from `appsettings.json` and an
+environment-specific file like `appsettings.Development.json` based on the value
+of the `ASPNETCORE_ENVIRONMENT` environment variable.
+
 ## Testing
 
 This repository already includes a small xUnit test project located in `BcodeSeed.Tests`. Run the tests with:


### PR DESCRIPTION
## Summary
- add a Development-specific settings file for the API
- mention how ASP.NET Core loads `appsettings.{Environment}.json` automatically

## Testing
- `dotnet test`
