### PR TITLE
Add minimal error handler

### DIFF
--- a/BcodeSeed.Api/Program.cs
+++ b/BcodeSeed.Api/Program.cs
@@ -9,6 +9,8 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
+app.UseExceptionHandler("/error");
+
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
@@ -21,5 +23,8 @@ app.UseHttpsRedirection();
 app.UseAuthorization();
 
 app.MapControllers();
+
+app.Map("/error", () => Results.Problem())
+   .ExcludeFromDescription();
 
 app.Run();

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ ASP.NET Core automatically loads configuration from `appsettings.json` and an
 environment-specific file like `appsettings.Development.json` based on the value
 of the `ASPNETCORE_ENVIRONMENT` environment variable.
 
+## Error Handling
+
+Unhandled exceptions are routed to a dedicated `/error` endpoint by
+`app.UseExceptionHandler("/error")`. The endpoint returns an RFC 7807
+problem response, ensuring clients receive consistent JSON error details.
+
 ## Testing
 
 This repository already includes a small xUnit test project located in `BcodeSeed.Tests`. Run the tests with:


### PR DESCRIPTION
## Summary
- configure `UseExceptionHandler` middleware
- expose a minimal `/error` endpoint for Problem details
- document error handling behavior in the README

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685d7fab0e1883249c3e10999cc9f80f