### PR TITLE
Add WeatherForecast integration test

### DIFF
--- a/BcodeSeed.Api/Program.cs
+++ b/BcodeSeed.Api/Program.cs
@@ -28,3 +28,5 @@ app.Map("/error", () => Results.Problem())
    .ExcludeFromDescription();
 
 app.Run();
+
+public partial class Program { }

--- a/BcodeSeed.Tests/BcodeSeed.Tests.csproj
+++ b/BcodeSeed.Tests/BcodeSeed.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BcodeSeed.Api\BcodeSeed.Api.csproj" />

--- a/BcodeSeed.Tests/Integration/WeatherForecastEndpointTests.cs
+++ b/BcodeSeed.Tests/Integration/WeatherForecastEndpointTests.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace BcodeSeed.Tests.Integration;
+
+public class WeatherForecastEndpointTests
+{
+    [Fact]
+    public async Task Get_ReturnsSuccess()
+    {
+        await using var factory = new WebApplicationFactory<BcodeSeed.Api.Program>();
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/weatherforecast");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/BcodeSeed.Tests/Integration/WeatherForecastEndpointTests.cs
+++ b/BcodeSeed.Tests/Integration/WeatherForecastEndpointTests.cs
@@ -9,7 +9,7 @@ public class WeatherForecastEndpointTests
     [Fact]
     public async Task Get_ReturnsSuccess()
     {
-        await using var factory = new WebApplicationFactory<BcodeSeed.Api.Program>();
+        await using var factory = new WebApplicationFactory<Program>();
         var client = factory.CreateClient();
         var response = await client.GetAsync("/weatherforecast");
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ dotnet test
 ```
 
 For an example of the testing approach, see the sample `WeatherForecastControllerTests` under `BcodeSeed.Tests/UnitTests`.
+An additional integration test `WeatherForecastEndpointTests` located in `BcodeSeed.Tests/Integration` verifies that the `/weatherforecast` endpoint responds with HTTP `200`.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add a package reference for `Microsoft.AspNetCore.Mvc.Testing`
- create an integration test that checks the `/weatherforecast` endpoint returns HTTP 200
- document the integration test in the README

## Testing
- `dotnet test` *(fails: Failed to retrieve package `Microsoft.AspNetCore.Mvc.Testing` due to network restrictions)*
