### PR TITLE
Allow configuring port via settings

### DIFF
--- a/BcodeSeed.Api/Program.cs
+++ b/BcodeSeed.Api/Program.cs
@@ -1,5 +1,15 @@
 var builder = WebApplication.CreateBuilder(args);
 
+var urls = builder.Configuration["Urls"] ?? builder.Configuration["URLS"];
+if (!string.IsNullOrWhiteSpace(urls))
+{
+    builder.WebHost.UseUrls(urls);
+}
+else if (builder.Configuration.GetValue<int?>("PORT") is { } port)
+{
+    builder.WebHost.UseUrls($"http://*:{port}");
+}
+
 // Add services to the container.
 
 builder.Services.AddControllers();

--- a/BcodeSeed.Api/appsettings.json
+++ b/BcodeSeed.Api/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "Urls": "https://localhost:5001;http://localhost:5000",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ dotnet run --project BcodeSeed.Api
 
 By default the API listens on `https://localhost:5001` (and `http://localhost:5000`). Swagger UI will be available at `https://localhost:5001/swagger`.
 
+### Configuring the Listening Port
+
+You can override the port by setting the `Urls` configuration value or the `PORT` environment variable. For example:
+
+```bash
+export PORT=8080
+dotnet run --project BcodeSeed.Api
+```
+
+Alternatively, edit `appsettings.json` and change the `Urls` setting:
+
+```json
+{
+  "Urls": "http://localhost:8080"
+}
+```
+
 ASP.NET Core automatically loads configuration from `appsettings.json` and an
 environment-specific file like `appsettings.Development.json` based on the value
 of the `ASPNETCORE_ENVIRONMENT` environment variable.


### PR DESCRIPTION
## Summary
- allow specifying a listening URL or PORT via configuration
- document the new configuration option

## Testing
- `dotnet test BcodeSeed.sln --no-build --verbosity normal` *(fails: dotnet not installed)*
