### PR TITLE
Limit .NET updates to LTS releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,19 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "limit dotnet docker images to stable LTS releases",
+      "matchManagers": ["dockerfile"],
+      "matchPackagePatterns": ["^mcr.microsoft.com/dotnet/"] ,
+      "allowedTags": "/^8\\./"
+    },
+    {
+      "description": "limit Microsoft.AspNetCore dependencies to LTS version",
+      "matchManagers": ["nuget"],
+      "matchPackagePrefixes": ["Microsoft.AspNetCore", "Microsoft.NETCore"],
+      "allowedVersions": "/^8\\./"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- keep Renovate from upgrading .NET Core unless it's an LTS release

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efb382bac8324b0e70fe7edbb884e