### PR TITLE
Fix invalid Renovate option allowedTags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
       "description": "limit dotnet docker images to stable LTS releases",
       "matchManagers": ["dockerfile"],
       "matchPackagePatterns": ["^mcr.microsoft.com/dotnet/"] ,
-      "allowedTags": "/^8\\./"
+      "allowedVersions": "/^8\\./"
     },
     {
       "description": "limit Microsoft.AspNetCore dependencies to LTS version",


### PR DESCRIPTION
## Summary
- fix the renovate config option in the first package rule

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_685effbadeac8324a623a3ff10ee8da9